### PR TITLE
Ignores array types as far as Migrator is concerned

### DIFF
--- a/lib/cloak_ecto/migrator.ex
+++ b/lib/cloak_ecto/migrator.ex
@@ -69,6 +69,10 @@ defmodule Cloak.Ecto.Migrator do
     false
   end
 
+  defp cloak_field?({_field, {:array, _type}}) do
+    false
+  end
+
   defp cloak_field?({_field, type}) do
     Code.ensure_loaded?(type) && function_exported?(type, :__cloak__, 0)
   end


### PR DESCRIPTION
Previously, a ecto type like {:array, :string} or {:array, :map} would be fed into Code.ensure_loaded?/1, raising an argument error. While it would be nice to be able to handle array types with encoded members, ecto does not seem to handle the encoding of arrays of binaries to postgres nicely, and having the database report the field as an array of binaries leaks more information than just having a binary type for the field and using Cloak.Ecto.Map to wrap the data in a way that can be turned back into the list you want by the app.