### PR TITLE
Revert ":crypto.hmac/3 is deprecated, switching to :crypto:mac/4 instead"

### DIFF
--- a/lib/cloak_ecto/types/hmac.ex
+++ b/lib/cloak_ecto/types/hmac.ex
@@ -142,7 +142,7 @@ defmodule Cloak.Ecto.HMAC do
 
       def dump(value) when is_binary(value) do
         config = build_config()
-        {:ok, :crypto.mac(:hmac, config[:algorithm], config[:secret], value)}
+        {:ok, :crypto.hmac(config[:algorithm], config[:secret], value)}
       end
 
       def dump(_value) do

--- a/test/cloak_ecto/types/hmac_test.exs
+++ b/test/cloak_ecto/types/hmac_test.exs
@@ -46,7 +46,7 @@ defmodule Cloak.Ecto.HMACTest do
 
     test "hashes binaries" do
       assert {:ok, hash} = HMAC.dump("plaintext")
-      assert hash == :crypto.mac(:hmac, :sha512, "secret", "plaintext")
+      assert hash == :crypto.hmac(:sha512, "secret", "plaintext")
     end
 
     test "returns :error for all other types" do


### PR DESCRIPTION
Reverts tinfoil/cloak_ecto#5

Alternative implementation implemented upstream